### PR TITLE
移动有关绑定相关的代码到真正的绑定函数中去。

### DIFF
--- a/src/FancyM/Mail.php
+++ b/src/FancyM/Mail.php
@@ -128,16 +128,8 @@ $smtp->sendmail($smtpemailto, $smtpusermail, $mailsubject, $mailbody, $mailtype)
             $s->sendMessage('无效邮箱');
             return true;
         }
-        if($this->bindMail($s,$e)){
-            $s->sendMessage('绑定成功');
-          
-		  $this->pl->set($s->getName(),$e);
-		  $this->pl->save();
-		   
-        }else{
-            $s->sendMessage('绑定失败');
-        
-        }
+        $this->bindMail($s,$e)
+        $s->sendMessage('绑定成功');
     }
 }
 
@@ -197,9 +189,8 @@ public function checkBind(Player $p){
  */
 public function bindMail(Player $p, $e ){
     $pn = $p->getName();
-    $cid = $p->getClientId();
-	
-	return true;
+	$this->pl->set($pn,$e);
+	$this->pl->save();
 	
     //TODO:绑定邮箱具体实现函数
 }


### PR DESCRIPTION
如果仅仅只是设置一下配置文件而无需进行邮箱验证的话，那么就几乎不会有绑定失败的情况，也无须判断。      
**仍然建议增加邮箱验证这一步骤。**            